### PR TITLE
Filter inactive questions and regrade participant answers

### DIFF
--- a/routes/test.routes.js
+++ b/routes/test.routes.js
@@ -19,6 +19,7 @@ const {
         updateTestAccess,
         getUserSessions,
         getParticipantsByInstance,
+        fixParticipantAnswers,
 } = await import('../controllers/test.controller.js')
 const { getTestSessionData, getCurrentSession, getQuestion, answerQuestion, setAsCompleted } =
 	await import('../controllers/test.controller.js')
@@ -45,6 +46,8 @@ router.post('/session/current', userOnly, getCurrentSession)
 router.post('/session/question', userOnly, getQuestion)
 router.post('/session/answer', userOnly, answerQuestion)
 router.get('/session/user', userOnly, getUserSessions)
+
+router.post('/session/fixanswers', webmasterOnly, fixParticipantAnswers)
 
 router.post('/user/sessions', webmasterOnly, getUserTestSessions)
 router.post('/participants/byinstance/get', webmasterOnly, getParticipantsByInstance)


### PR DESCRIPTION
## Summary
- serve only active questions to participants when starting test
- add webmaster route to recompute participant answer correctness

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee2a7c38832383464c3b93303d97